### PR TITLE
Re-adds lazysizes support

### DIFF
--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -3,6 +3,10 @@ img {
   height: auto;
 }
 
+img[data-sizes="auto"] {
+  display: block; 
+}
+
 img, picture {
   font-size: 0;
 }

--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -1,6 +1,6 @@
 img {
-  height: auto;
   max-width: 100%;
+  height: auto;
 }
 
 img, picture {
@@ -16,4 +16,13 @@ figcaption {
 .content .gitpod-mark-monochrome.icon {
   margin-bottom: 0.125rem;
   margin-right: 0.5rem;
+}
+
+.blur-up {
+  filter: blur(5px);
+  transition: filter 400ms;
+}
+
+.blur-up.lazyloaded {
+  filter: unset;
 }

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -127,6 +127,7 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 {{- $fetchPriority := or .fetchpriority site.Params.hyas_images.defaults.fetchpriority }}
 {{- $loading := or .loading site.Params.hyas_images.defaults.loading }}
 {{- $process := or .process site.Params.hyas_images.defaults.process }}
+{{- $lqip := or .lqip site.Params.hyas_images.defaults.lqip }}
 {{- $src := or .src "" }}
 {{- $title := or .title "" }}
 {{- $caption := or .caption "" }}
@@ -164,15 +165,15 @@ Add this CSS to your site to remove small gaps between adjacent elements:
   {{- $r = . }}
 {{- end }}
 
-{{/* Convert to webp. */}}
-{{- $f := site.Params.hyas_images.defaults.format }}
-{{- if eq $f "webp" }}
-  {{- $r = $r.Resize (printf "%dx%d webp" $r.Width $r.Height) }}
-{{- end }}
-
 {{- /* Process image. */}}
 {{- with $process }}
   {{- $r = $r.Process $process }}
+{{- end }}
+
+{{- /* Process LQIP. */}}
+{{- $l := "" }}
+{{- with $lqip }}
+  {{- $l = $r.Resize . }}
 {{- end }}
 
 {{- /* Determine widths for srcset generation. */}}
@@ -216,29 +217,30 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 {{- /* Render. */}}
 <figure>
   <img
+    srcset="data:{{ $l.MediaType }};base64,{{ $l.Content | base64Encode }}"
     {{- range $formats }}
       {{- with index $im . }}
         {{- $sizes := $stdSizes }}
         {{- with $width }}
           {{- $sizes = printf "%dpx" . }}
         {{- end }}
-        srcset="
+        data-srcset="
           {{- range $k, $_ := . }}
             {{- if $k }},{{- end }}
             {{- printf `%s %dw` .RelPermalink .Width }}
           {{- end }}"
-        sizes="{{ $stdSizes }}"
+        data-sizes="{{ $stdSizes }}"
       {{- end }}
     {{- end }}
     src="{{ $fi.RelPermalink }}"
     width="{{ string $r.Width }}"
     height="{{ string $r.Height }}"
     decoding="{{ $decoding }}"
-    fetchpriority="{{ site.Params.hyas_images.defaults.fetchpriority }}"
+    fetchpriority="{{ $fetchPriority }}"
     loading="{{ $loading }}"
     alt="{{ $alt }}"
-    {{- with .title -}}title="{{ $title }}"{{- end -}}
-    {{- with .class -}}class="{{ $class }}"{{- end -}}
+    {{- with .title }}title="{{ $title }}"{{- end }}
+    class="lazyload blur-up{{- with .class }} {{ . }}{{- end }}"
   />
   {{- with $caption }}<figcaption>{{ . }}</figcaption>{{- end }}
 </figure>

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -62,7 +62,8 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 @contect {int} [width] The display width of the image, in pixels, falling back to 100% of the viewport width.
 @context {string} [sizes] = "" # "100vw", "75vw", or "auto" for example
 @context {string slice} [formats] A slice of image formats, ordered by precedence, to use when creating images for the srcset attribute of each source element.
-@context {string} [process] = "" # "fill 1680x720" for example
+@context {string} [process] = "" # "fill 1600x900" for example
+@context {string} [lqip] = "" # "16x webp q20" or "21x webp q20" for example
 @context {string} [decoding] The img element's decoding attribute.
 @context {string} [fetchpriority] The img element's fetchpriority attribute.
 @context {string} [loading] The img element's loading attribute.
@@ -84,7 +85,8 @@ Add this CSS to your site to remove small gaps between adjacent elements:
     "width" 768
     "sizes" "auto"
     "formats" (slice "webp" "jpeg")
-    "process" "fill 1680x720"
+    "process" "fill 1600x900"
+    "lqip" "16x webp q20"
     "decoding" "async"
     "fetchpriority" "auto"
     "loading" "eager"

--- a/layouts/partials/figure.html
+++ b/layouts/partials/figure.html
@@ -241,7 +241,7 @@ Add this CSS to your site to remove small gaps between adjacent elements:
     alt="{{ $alt }}"
     {{- with .title }}title="{{ $title }}"{{- end }}
     class="lazyload blur-up{{- with .class }} {{ . }}{{- end }}"
-  />
+  >
   {{- with $caption }}<figcaption>{{ . }}</figcaption>{{- end }}
 </figure>
 

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -62,7 +62,8 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 @contect {int} [width] The display width of the image, in pixels, falling back to 100% of the viewport width.
 @context {string} [sizes] = "" # "100vw", "75vw", or "auto" for example
 @context {string slice} [formats] A slice of image formats, ordered by precedence, to use when creating images for the srcset attribute of each source element.
-@context {string} [process] = "" # "fill 1680x720" for example
+@context {string} [process] = "" # "fill 1600x900" for example
+@context {string} [lqip] = "" # "16x webp q20" or "21x webp q20" for example
 @context {string} [decoding] The img element's decoding attribute.
 @context {string} [fetchpriority] The img element's fetchpriority attribute.
 @context {string} [loading] The img element's loading attribute.
@@ -83,7 +84,8 @@ Add this CSS to your site to remove small gaps between adjacent elements:
     "width" 768
     "sizes" "auto"
     "formats" (slice "webp" "jpeg")
-    "process" "fill 1680x720"
+    "process" "fill 1600x900"
+    "lqip" "16x webp q20"
     "decoding" "async"
     "fetchpriority" "auto"
     "loading" "eager"

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -237,7 +237,7 @@ Add this CSS to your site to remove small gaps between adjacent elements:
   alt="{{ $alt }}"
   {{- with .title }}title="{{ $title }}"{{- end }}
   class="lazyload blur-up{{- with .class }} {{ . }}{{- end }}"
-/>
+>
 
 {{- define "partials/inline/capture-resource.html" }}
   {{- /* Parse destination. */}}

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -125,6 +125,7 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 {{- $fetchPriority := or .fetchpriority site.Params.hyas_images.defaults.fetchpriority }}
 {{- $loading := or .loading site.Params.hyas_images.defaults.loading }}
 {{- $process := or .process site.Params.hyas_images.defaults.process }}
+{{- $lqip := or .lqip site.Params.hyas_images.defaults.lqip }}
 {{- $src := or .src "" }}
 {{- $title := or .title "" }}
 {{- $width := or (int .width) 0 }}
@@ -161,15 +162,15 @@ Add this CSS to your site to remove small gaps between adjacent elements:
   {{- $r = . }}
 {{- end }}
 
-{{/* Convert to webp. */}}
-{{- $f := site.Params.hyas_images.defaults.format }}
-{{- if eq $f "webp" }}
-  {{- $r = $r.Resize (printf "%dx%d webp" $r.Width $r.Height) }}
-{{- end }}
-
 {{- /* Process image. */}}
 {{- with $process }}
   {{- $r = $r.Process $process }}
+{{- end }}
+
+{{- /* Process LQIP. */}}
+{{- $l := "" }}
+{{- with $lqip }}
+  {{- $l = $r.Resize . }}
 {{- end }}
 
 {{- /* Determine widths for srcset generation. */}}
@@ -212,29 +213,30 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 
 {{- /* Render. */}}
 <img
+  srcset="data:{{ $l.MediaType }};base64,{{ $l.Content | base64Encode }}"
   {{- range $formats }}
     {{- with index $im . }}
       {{- $sizes := $stdSizes }}
       {{- with $width }}
         {{- $sizes = printf "%dpx" . }}
       {{- end }}
-      srcset="
+      data-srcset="
         {{- range $k, $_ := . }}
           {{- if $k }},{{- end }}
           {{- printf `%s %dw` .RelPermalink .Width }}
         {{- end }}"
-      sizes="{{ $stdSizes }}"
+      data-sizes="{{ $stdSizes }}"
     {{- end }}
   {{- end }}
   src="{{ $fi.RelPermalink }}"
   width="{{ string $r.Width }}"
   height="{{ string $r.Height }}"
   decoding="{{ $decoding }}"
-  fetchpriority="{{ site.Params.hyas_images.defaults.fetchpriority }}"
+  fetchpriority="{{ $fetchPriority }}"
   loading="{{ $loading }}"
   alt="{{ $alt }}"
-  {{- with .title -}}title="{{ $title }}"{{- end -}}
-  {{- with .class -}}class="{{ $class }}"{{- end -}}
+  {{- with .title }}title="{{ $title }}"{{- end }}
+  class="lazyload blur-up{{- with .class }} {{ . }}{{- end }}"
 />
 
 {{- define "partials/inline/capture-resource.html" }}

--- a/layouts/partials/picture.html
+++ b/layouts/partials/picture.html
@@ -62,7 +62,8 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 @contect {int} [width] The display width of the image, in pixels, falling back to 100% of the viewport width.
 @context {string} [sizes] = "" # "100vw", "75vw", or "auto" for example
 @context {string slice} [formats] A slice of image formats, ordered by precedence, to use when creating images for the srcset attribute of each source element.
-@context {string} [process] = "" # "fill 1680x720" for example
+@context {string} [process] = "" # "fill 1600x900" for example
+@context {string} [lqip] = "" # "16x webp q20" or "21x webp q20" for example
 @context {string} [decoding] The img element's decoding attribute.
 @context {string} [fetchpriority] The img element's fetchpriority attribute.
 @context {string} [loading] The img element's loading attribute.
@@ -83,7 +84,8 @@ Add this CSS to your site to remove small gaps between adjacent elements:
     "width" 768
     "sizes" "auto"
     "formats" (slice "webp" "jpeg")
-    "process" "fill 1680x720"
+    "process" "fill 1600x900"
+    "lqip" "16x webp q20"
     "decoding" "async"
     "fetchpriority" "auto"
     "loading" "eager"

--- a/layouts/partials/picture.html
+++ b/layouts/partials/picture.html
@@ -238,7 +238,7 @@ Add this CSS to your site to remove small gaps between adjacent elements:
     alt="{{ $alt }}"
     {{- with .title }}title="{{ $title }}"{{- end }}
     class="lazyload blur-up{{- with .class }} {{ . }}{{- end }}"
-  />
+  >
 </picture>
 
 {{- define "partials/inline/capture-resource.html" }}

--- a/layouts/partials/picture.html
+++ b/layouts/partials/picture.html
@@ -125,6 +125,7 @@ Add this CSS to your site to remove small gaps between adjacent elements:
 {{- $fetchPriority := or .fetchpriority site.Params.hyas_images.defaults.fetchpriority }}
 {{- $loading := or .loading site.Params.hyas_images.defaults.loading }}
 {{- $process := or .process site.Params.hyas_images.defaults.process }}
+{{- $lqip := or .lqip site.Params.hyas_images.defaults.lqip }}
 {{- $src := or .src "" }}
 {{- $title := or .title "" }}
 {{- $width := or (int .width) 0 }}
@@ -161,15 +162,15 @@ Add this CSS to your site to remove small gaps between adjacent elements:
   {{- $r = . }}
 {{- end }}
 
-{{/* Convert to webp. */}}
-{{- $f := site.Params.hyas_images.defaults.format }}
-{{- if eq $f "webp" }}
-  {{- $r = $r.Resize (printf "%dx%d webp" $r.Width $r.Height) }}
-{{- end }}
-
 {{- /* Process image. */}}
 {{- with $process }}
   {{- $r = $r.Process $process }}
+{{- end }}
+
+{{- /* Process LQIP. */}}
+{{- $l := "" }}
+{{- with $lqip }}
+  {{- $l = $r.Resize . }}
 {{- end }}
 
 {{- /* Determine widths for srcset generation. */}}
@@ -218,24 +219,25 @@ Add this CSS to your site to remove small gaps between adjacent elements:
       {{- with $width }}
         {{- $sizes = printf "%dpx" . }}
       {{- end }}
-      <source type="{{ (index . 0).MediaType.Type }}" srcset="
+      <source type="{{ (index . 0).MediaType.Type }}" data-srcset="
         {{- range $k, $_ := . }}
           {{- if $k }},{{- end }}
           {{- printf `%s %dw` .RelPermalink .Width }}
         {{- end }}"
-        sizes="{{ $stdSizes }}">
+        data-sizes="{{ $stdSizes }}">
     {{- end }}
   {{- end }}
   <img
-    src="{{ $fi.RelPermalink }}"
+    src="data:{{ $l.MediaType }};base64,{{ $l.Content | base64Encode }}"
+    data-src="{{ $fi.RelPermalink }}"
     width="{{ string $r.Width }}"
     height="{{ string $r.Height }}"
     decoding="{{ $decoding }}"
-    fetchpriority="{{ site.Params.hyas_images.defaults.fetchpriority }}"
+    fetchpriority="{{ $fetchPriority }}"
     loading="{{ $loading }}"
     alt="{{ $alt }}"
-    {{- with .title -}}title="{{ $title }}"{{- end -}}
-    {{- with .class -}}class="{{ $class }}"{{- end -}}
+    {{- with .title }}title="{{ $title }}"{{- end }}
+    class="lazyload blur-up{{- with .class }} {{ . }}{{- end }}"
   />
 </picture>
 

--- a/layouts/shortcodes/figure.html
+++ b/layouts/shortcodes/figure.html
@@ -75,7 +75,8 @@ This shortcode is a wrapper for, and requires, the figure partial:
 @param {int} [width] The display width of the image, in pixels, falling back to 100% of the viewport width.
 @param {string} [sizes] = "" # "100vw", "75vw", or "auto" for example
 @param {string slice} [formats] A slice of image formats, ordered by precedence, to use when creating images for the srcset attribute of each source element.
-@param {string} [process] = "" # "fill 1680x720" for example
+@param {string} [process] = "" # "fill 1600x900" for example
+@param {string} [lqip] = "" # "16x webp q20" or "21x webp q20" for example
 @param {string} [decoding] The img element's decoding attribute.
 @param {string} [fetchpriority] The img element's fetchpriority attribute.
 @param {string} [loading] The img element's loading attribute.
@@ -97,7 +98,8 @@ This shortcode is a wrapper for, and requires, the figure partial:
     width=768
     sizes="75w"
     formats="webp, jpeg"
-    process="fill 1680x720"
+    process="fill 1600x900"
+    lqip="16x webp q20"
     decoding="async"
     fetchpriority="auto"
     loading="eager"

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -75,7 +75,8 @@ This shortcode is a wrapper for, and requires, the img partial:
 @param {int} [width] The display width of the image, in pixels, falling back to 100% of the viewport width.
 @param {string} [sizes] = "" # "100vw", "75vw", or "auto" for example
 @param {string slice} [formats] A slice of image formats, ordered by precedence, to use when creating images for the srcset attribute of each source element.
-@param {string} [process] = "" # "fill 1680x720" for example
+@param {string} [process] = "" # "fill 1600x900" for example
+@param {string} [lqip] = "" # "16x webp q20" or "21x webp q20" for example
 @param {string} [decoding] The img element's decoding attribute.
 @param {string} [fetchpriority] The img element's fetchpriority attribute.
 @param {string} [loading] The img element's loading attribute.
@@ -96,7 +97,8 @@ This shortcode is a wrapper for, and requires, the img partial:
     width=768
     sizes="75w"
     formats="webp, jpeg"
-    process="fill 1680x720"
+    process="fill 1600x900"
+    lqip="16x webp q20"
     decoding="async"
     fetchpriority="auto"
     loading="eager"

--- a/layouts/shortcodes/picture.html
+++ b/layouts/shortcodes/picture.html
@@ -75,7 +75,8 @@ This shortcode is a wrapper for, and requires, the picture partial:
 @param {int} [width] The display width of the image, in pixels, falling back to 100% of the viewport width.
 @param {string} [sizes] = "" # "100vw", "75vw", or "auto" for example
 @param {string slice} [formats] A slice of image formats, ordered by precedence, to use when creating images for the srcset attribute of each source element.
-@param {string} [process] = "" # "fill 1680x720" for example
+@param {string} [process] = "" # "fill 1600x900" for example
+@param {string} [lqip] = "" # "16x webp q20" or "21x webp q20" for example
 @param {string} [decoding] The img element's decoding attribute.
 @param {string} [fetchpriority] The img element's fetchpriority attribute.
 @param {string} [loading] The img element's loading attribute.
@@ -96,7 +97,8 @@ This shortcode is a wrapper for, and requires, the picture partial:
     width=768
     sizes="75w"
     formats="webp, jpeg"
-    process="fill 1680x720"
+    process="fill 1600x900"
+    lqip="16x webp q20"
     decoding="async"
     fetchpriority="auto"
     loading="eager"


### PR DESCRIPTION
## Summary

Including support for `sizes=auto` and LQIP with blur-up effect.

Update partials:
- [x] `img`
- [x] `picture`
- [x] `figure`

## Basic example

Include a basic example, screenshots, or links.

## Motivation

Why are we doing this? What use cases does it support? What is the expected outcome?

## Checks

- [ ] Read [Create a Pull Request](https://gethyas.com/docs/contributing/how-to-contribute/#create-a-pull-request)
- [ ] Supports all screen sizes (if relevant)
- [ ] Supports both light and dark mode (if relevant)
- [ ] Passes `npm run test`
