### PR TITLE
Fix invalid HTML on img tag for render hook

### DIFF
--- a/.changeset/spicy-cheetahs-refuse.md
+++ b/.changeset/spicy-cheetahs-refuse.md
@@ -1,0 +1,5 @@
+---
+"@thulite/images": patch
+---
+
+Fix invalid HTML on img tag for render hook

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -165,8 +165,8 @@ partial template, after the render hook has captured the resource.
   fetchpriority="{{ site.Params.thulite_images.defaults.fetchpriority }}"
   loading="{{ site.Params.thulite_images.defaults.loading }}"
   alt="{{ .PlainText }}"
-  {{- with .Title -}}title="{{ . }}"{{- end -}}
+  {{- with .Title -}}title="{{ . }}"{{- end }}
   id="{{ $id }}"
-/>
+>
 
 {{- /**/ -}}


### PR DESCRIPTION
Closes Markdown images fail w3 validator HTML validation Fixes #31

## Summary

1. Ensure whitespace between `alt` or `title` and `id` for render-hook generated `img` tag
2. Remove trailing `/` from `img` tag.

## Motivation

These align the output HTML with W3 recommendations, as identified by the W3 Nu Validator.
Fixes #31 

## Basic example

No user-facing change.

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test` (if relevant)
