### PR TITLE
Rebase fix svg images in markdown

### DIFF
--- a/.changeset/calm-moose-kneel.md
+++ b/.changeset/calm-moose-kneel.md
@@ -1,0 +1,5 @@
+---
+"@thulite/images": patch
+---
+
+Rebase fix svg images in markdown

--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -33,5 +33,5 @@ figcaption {
 }
 
 .markdown-svg {
-  background-color: #fff;
+  background-color: var(--markdown-svg, transparent);
 }

--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -31,3 +31,7 @@ figcaption {
 .blur-up.lazyloaded {
     filter: unset;
 }
+
+.markdown-svg {
+  background-color: #fff;
+}

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -178,7 +178,7 @@ partial template, after the render hook has captured the resource.
   alt="{{ .PlainText }}"
   {{- with .Title -}}title="{{ . }}"{{- end }}
   id="{{ $id }}"
-  class="svg-img-render-hook"
+  class="svg-img markdown-svg"
 >
 {{- end }}
 

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -178,7 +178,7 @@ partial template, after the render hook has captured the resource.
   alt="{{ .PlainText }}"
   {{- with .Title -}}title="{{ . }}"{{- end }}
   id="{{ $id }}"
-  class="svg-img markdown-svg"
+  class="markdown-svg"
 >
 {{- end }}
 

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -152,10 +152,11 @@ partial template, after the render hook has captured the resource.
 {{- end }}
 
 {{/* Convert to webp. */}}
-{{- if ne $r.MediaType.SubType "gif" }}
+{{- if not (in (slice "gif" "svg") $r.MediaType.SubType) }}
   {{- $r = $r.Resize (printf "%dx%d webp" $r.Width $r.Height) }}
 {{- end }}
 
+{{- if ne $r.MediaType.SubType "svg" }}
 {{- /* Render image element. */ -}}
 <img
   src="{{ $r.RelPermalink }}"
@@ -168,5 +169,17 @@ partial template, after the render hook has captured the resource.
   {{- with .Title -}}title="{{ . }}"{{- end }}
   id="{{ $id }}"
 >
+{{- else }}
+<img
+  src="{{ $r.RelPermalink }}"
+  decoding="{{ site.Params.thulite_images.defaults.decoding }}"
+  fetchpriority="{{ site.Params.thulite_images.defaults.fetchpriority }}"
+  loading="{{ site.Params.thulite_images.defaults.loading }}"
+  alt="{{ .PlainText }}"
+  {{- with .Title -}}title="{{ . }}"{{- end }}
+  id="{{ $id }}"
+  class="svg-img-render-hook"
+>
+{{- end }}
 
 {{- /**/ -}}


### PR DESCRIPTION
## Summary

1. Skip converting image to webp (it only works for raster images)
2. Use alternate attributes for `img` tag when image is an SVG. Notably:
   1. Do not attempt to get width and height from resource - this only works with raster images
   2. Add a class so we can target these images specifically
3. Use the class above to set the default background on SVG img tags from markdown render hooks to be white. This allows the image to display correctly in both dark and light modes.
   * NOTE: In a future pull request the hard-coded white will be changed to be configurable
     by a page parameter so that it becomes user-configurable. Because the default for the
     'stroke' is usually black (#000), it is necessary for force the background to be light,
     even for a dark theme, however to handle images with a different stroke colour a more
     complex solution is required. This will also require a change to
     <https://github.com/thulite/doks-core>.

## Basic example

```markdown
![An SVG image](image.svg)
```

now works.

<img width="768" height="273" alt="image" src="https://github.com/user-attachments/assets/bd5585b2-a495-456e-bccf-c0f8361255ae" />

## Motivation

Fixes #29 

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test` (if relevant)
