### PR TITLE
Avoid hard coding markdown svg background colour

### DIFF
--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -33,5 +33,5 @@ figcaption {
 }
 
 .markdown-svg {
-  background-color: #fff;
+  background-color: var(--markdown-svg, #fff);
 }

--- a/assets/scss/components/_images.scss
+++ b/assets/scss/components/_images.scss
@@ -31,3 +31,7 @@ figcaption {
 .blur-up.lazyloaded {
     filter: unset;
 }
+
+.markdown-svg {
+  background-color: #fff;
+}

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -178,7 +178,7 @@ partial template, after the render hook has captured the resource.
   alt="{{ .PlainText }}"
   {{- with .Title -}}title="{{ . }}"{{- end }}
   id="{{ $id }}"
-  class="svg-img-render-hook"
+  class="svg-img markdown-svg"
 >
 {{- end }}
 

--- a/layouts/_markup/render-image.html
+++ b/layouts/_markup/render-image.html
@@ -152,10 +152,11 @@ partial template, after the render hook has captured the resource.
 {{- end }}
 
 {{/* Convert to webp. */}}
-{{- if ne $r.MediaType.SubType "gif" }}
+{{- if not (in (slice "gif" "svg") $r.MediaType.SubType) }}
   {{- $r = $r.Resize (printf "%dx%d webp" $r.Width $r.Height) }}
 {{- end }}
 
+{{- if ne $r.MediaType.SubType "svg" }}
 {{- /* Render image element. */ -}}
 <img
   src="{{ $r.RelPermalink }}"
@@ -168,5 +169,17 @@ partial template, after the render hook has captured the resource.
   {{- with .Title -}}title="{{ . }}"{{- end }}
   id="{{ $id }}"
 >
+{{- else }}
+<img
+  src="{{ $r.RelPermalink }}"
+  decoding="{{ site.Params.thulite_images.defaults.decoding }}"
+  fetchpriority="{{ site.Params.thulite_images.defaults.fetchpriority }}"
+  loading="{{ site.Params.thulite_images.defaults.loading }}"
+  alt="{{ .PlainText }}"
+  {{- with .Title -}}title="{{ . }}"{{- end }}
+  id="{{ $id }}"
+  class="svg-img-render-hook"
+>
+{{- end }}
 
 {{- /**/ -}}


### PR DESCRIPTION
## Summary

Depends on https://github.com/thuliteio/images/pull/36 (Rebase fix svg images in markdown) and https://github.com/thuliteio/core/pull/26 (add custom  CSS properties from Params)

in order to allow site or page level configuration of the background colour for markdown svg images.

## Basic example

In `params.toml`

```toml
[cssVars]
   'markdown-svg' = '#fff'
```

would result in (in `<head>`):

```html
<style>:root { --markdown-svg:#fff; }</style>
```

which would set the background colour for a Markdown rendered SVG image to white (#fff).

## Motivation

To avoid hard-coding the background colour of SVG images from inline Markdown after #36. 

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant) (not relevant)
- [ ] Supports both light and dark mode (if relevant) -- It allows customization but not per-mode; that would probably be overkill an difficult given the root cause issue this solves.
- [x] Passes `npm run test` (if relevant) (not relevant)
